### PR TITLE
add missing policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -69,6 +69,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
This lambda needs to read cloudformation stacks and was missing the
policy to do so.  This adds the missing policy.
